### PR TITLE
Make fallback TV detection a bit more strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ module.exports = exports = function (_ua, obj) {
   var _tablet = 'tablet'
   var _windows = 'windows'
   var _phone = 'phone'
-  var _firetv = 'firetv'
   var _facebook = 'facebook'
   var _edge = 'edge'
   var _version = 'version'
@@ -39,7 +38,7 @@ module.exports = exports = function (_ua, obj) {
     function (query, arr) {
       obj.browser = arr[2] || query
       var _v = _ua.match(
-        new RegExp('((([\\/ ]' + _version + '|' + arr[ 0 ] + '(?!.+' + _version + '))[\/ ])| rv:)([0-9]{1,4}\\.[0-9]{0,2})')
+        new RegExp('((([\\/ ]' + _version + '|' + arr[ 0 ] + '(?!.+' + _version + '))[/ ])| rv:)([0-9]{1,4}\\.[0-9]{0,2})')
       )
       obj[_version] = _v ? Number(_v[4]) : 0
       obj.prefix = arr[1]
@@ -53,7 +52,7 @@ module.exports = exports = function (_ua, obj) {
     [ 'opera', 'O' ],
     [ 'msie', 'ms', 'ie' ],
     [ _facebook ],
-    [ _chrome + '|crios\/', _webkit, _chrome ],
+    [ _chrome + '|crios/', _webkit, _chrome ],
     [ _edge, _webkit, _edge ],
     [ node, false, true ]
   )
@@ -91,7 +90,7 @@ module.exports = exports = function (_ua, obj) {
     [ _xbox + '|' + _ps, 'console' ],
     [ _castDetect, _chromecast ],
     [ _tablet + '|amazon-fireos|nexus (?=[^1-6])\\d{1,2}', _tablet ],
-    [ 'tv|smarttv|googletv|appletv|hbbtv|pov_tv|netcast.tv|webos.+large|viera|aft[bsm]|bravia', 'tv' ],
+    [ '\\btv\\b|smarttv|googletv|appletv|hbbtv|pov_tv|netcast.tv|webos.+large|viera|aft[bsm]|bravia', 'tv' ],
     [ 'mozilla\\/5.0 \\(compatible; .+http:\\/\\/', 'bot' ],
     [ node, 'server' ]
   )

--- a/test/common/devices.js
+++ b/test/common/devices.js
@@ -39,6 +39,15 @@ test('devices - iPhone', function (t) {
   }, t)
 })
 
+test('devices - iPhone wrapper', function (t) {
+  t.plan(useragents.ployNative.length * 2)
+  check({
+    list: useragents.ployNative,
+    platform: 'ios',
+    device: 'phone'
+  }, t)
+})
+
 test('devices - iPod', function (t) {
   t.plan(useragents.iPod.length * 2)
   check({
@@ -109,8 +118,6 @@ test('devices - bots', function (t) {
   }, t)
   t.end()
 })
-
-
 
 function check (params, t) {
   var result

--- a/test/common/useragents/list.js
+++ b/test/common/useragents/list.js
@@ -41,7 +41,7 @@ exports.iPhone = [
   'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1',
   // ios 9
   'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13B137',
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
   // ios 4
   'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_3 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5',
   'Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_1 like Mac OS X; zh-cn) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8G4 Safari/6533.18.5',
@@ -61,7 +61,7 @@ exports.iPad = [
   // ios 10
   'Mozilla/5.0 (iPad; CPU OS 10_3 like Mac OS X) AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1',
   // ios 9
-  "Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1",
+  'Mozilla/5.0 (iPad; CPU OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1',
   // ios 7
   'Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) CriOS/30.0.1599.12 Mobile/11A465 Safari/8536.25 (3B92C18B-D9DE-4CB7-A02A-22FD2AF17C8F)'
 ]
@@ -107,7 +107,9 @@ exports.sticktv = ['Mozilla/5.0 (Linux; Android 4.2.2; AFTM Build/JDQ39) AppleWe
 exports.rikstv = ['Ekioh/2.2.8.2 (Linux; Oct 31 2013; r12704) RiksTV/Strongv1']
 
 exports.ployNative = [
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 ploy-native"
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1 ploy-native',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E304  *VG*ploy-native,webkit,v1.0.0',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E304  *VG*ploy-native,webkit,com.example.tvae,v1.0.0'
 ]
 
 exports.chromeCast =


### PR DESCRIPTION
Handle the case when User Agent string contains 'tv' as a part of the word. Add tests.