### PR TITLE
Fix version detection for Chrome on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = exports = function (_ua, obj) {
     [ 'opera', 'O' ],
     [ 'msie', 'ms', 'ie' ],
     [ _facebook ],
-    [ _chrome + '|crios/', _webkit, _chrome ],
+    [ _chrome + '|crios', _webkit, _chrome ],
     [ _edge, _webkit, _edge ],
     [ node, false, true ]
   )

--- a/test/common/devices.js
+++ b/test/common/devices.js
@@ -119,6 +119,14 @@ test('devices - bots', function (t) {
   t.end()
 })
 
+test('devices - chrome ios version detection', function (t) {
+  var result = ua('Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) CriOS/30.0.1599.12 Mobile/11A465 Safari/8536.25 (3B92C18B-D9DE-4CB7-A02A-22FD2AF17C8F)')
+  t.equals(result.platform, 'ios')
+  t.equals(result.browser, 'chrome')
+  t.equals(result.version, 30)
+  t.end()
+})
+
 function check (params, t) {
   var result
   for (var i in params.list) {


### PR DESCRIPTION
The extra slash after `crios` in the pattern caused Chrome on iOS to always have `version` set to zero.